### PR TITLE
backendCache dogpile protection

### DIFF
--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -23,10 +23,13 @@ var DefaultLoggerConfig = zapwriter.Config{
 }
 
 type CacheConfig struct {
-	Type              string   `mapstructure:"type"`
-	Size              int      `mapstructure:"size_mb"`
-	MemcachedServers  []string `mapstructure:"memcachedServers"`
-	DefaultTimeoutSec int32    `mapstructure:"defaultTimeoutSec"`
+	Type                            string   `mapstructure:"type"`
+	Size                            int      `mapstructure:"size_mb"`
+	MemcachedServers                []string `mapstructure:"memcachedServers"`
+	DefaultTimeoutSec               int32    `mapstructure:"defaultTimeoutSec"`
+	DogpileProtection               bool     `mapstructure:"dogpileProtection"`
+	DogpileProtectionLockTimeoutSec int32    `mapstructure:"dogpileProtectionLockTimeoutSec"`
+	DogpileProtectionRetryDelayMs   int      `mapstructure:"dogpileProtectionRetryDelayMs"`
 }
 
 type GraphiteConfig struct {

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -159,6 +159,11 @@ func SetUpConfig(logger *zap.Logger, BuildVersion string) {
 
 	Config.ResponseCache = createCache(logger, "cache", Config.ResponseCacheConfig)
 	Config.BackendCache = createCache(logger, "backendCache", Config.BackendCacheConfig)
+	if Config.BackendCacheConfig.DogpileProtection && Config.BackendCacheConfig.Type != "memcache" {
+		// dogpile protection is only effective for memcache
+		Config.BackendCacheConfig.DogpileProtection = false
+		logger.Warn("dogpile protection is enabled in the config but the cache type is not memcache, this has no effect")
+	}
 
 	if Config.TimezoneString != "" {
 		fields := strings.Split(Config.TimezoneString, ",")
@@ -310,6 +315,8 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.BindEnv("tz", "carbonapi_tz")
 	viper.SetDefault("listen", "localhost:8081")
+	viper.SetDefault("backendCache.dogpileProtectionLockTimeoutSec", 60)
+	viper.SetDefault("backendCache.dogpileProtectionRetryDelayMs", 100)
 	viper.SetDefault("concurency", 20)
 	viper.SetDefault("cache.type", "mem")
 	viper.SetDefault("cache.size_mb", 0)


### PR DESCRIPTION
Prevent multiple compute of the same data when using `memcache` cache backend.

It's opt-in, meaning that the current behavior is not modified unless explicitly configured.

It uses a pseudo-lock on `memcache`. In the worst case where a `carbonapi` server is slow or dies while holding the lock, the lock expires and the value is recomputed. 